### PR TITLE
Fix Tailwind compatibility with Modern.js plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "uuid": "latest"
   },
   "peerDependencies": {
-    "react": "latest",
-    "react-dom": "latest",
-    "react-hook-form": "latest"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -105,6 +105,7 @@
     "react-dom": "latest",
     "rimraf": "latest",
     "storybook-addon-pseudo-states": "latest",
+    "tailwindcss": "^3.4.14",
     "typescript": "latest"
   },
   "sideEffects": [],

--- a/patches/@modern-js__plugin-tailwindcss.patch
+++ b/patches/@modern-js__plugin-tailwindcss.patch
@@ -1,0 +1,129 @@
+diff --git a/dist/cjs/config.js b/dist/cjs/config.js
+index f79f08921cd66a0e26347b4f828c11cdf7ddb25f..be4d1062c861b5adf941d20fc6055f82d6d72451 100644
+--- a/dist/cjs/config.js
++++ b/dist/cjs/config.js
+@@ -82,7 +82,9 @@ async function loadConfigFile(appDirectory) {
+ }
+ const getTailwindConfig = ({ tailwindVersion, appDirectory, userConfig, extraConfig, designSystem }) => {
+   const content = getDefaultContent(appDirectory);
+-  let tailwindConfig = tailwindVersion === "3" ? {
++  const tailwindMajor = Number.parseInt(tailwindVersion, 10);
++  const useContentConfig = Number.isNaN(tailwindMajor) || tailwindMajor >= 3;
++  let tailwindConfig = useContentConfig ? {
+     content
+   } : {
+     purge: getV2PurgeConfig(content)
+diff --git a/dist/cjs/utils.js b/dist/cjs/utils.js
+index 37b927d237e55967f4fb6e17a9ae66cb59c52748..728ccb8132573283d394c3b9bb56ca46bb7eca4a 100644
+--- a/dist/cjs/utils.js
++++ b/dist/cjs/utils.js
+@@ -22,18 +22,22 @@ __export(utils_exports, {
+   getTailwindVersion: () => getTailwindVersion
+ });
+ module.exports = __toCommonJS(utils_exports);
+-function getTailwindPath(appDirectory) {
++function resolveFromPackage(packageName, appDirectory) {
+   try {
+-    return require.resolve("tailwindcss", {
++    return require.resolve(packageName, {
+       paths: [
+         appDirectory,
+         __dirname
+       ]
+     });
+   } catch (err) {
+-    return "tailwindcss";
++    return null;
+   }
+ }
++function getTailwindPath(appDirectory) {
++  var _a, _b;
++  return (_b = (_a = resolveFromPackage("@tailwindcss/postcss", appDirectory)) !== null && _a !== void 0 ? _a : resolveFromPackage("tailwindcss", appDirectory)) !== null && _b !== void 0 ? _b : "tailwindcss";
++}
+ function getTailwindVersion(appDirectory) {
+   try {
+     const packageJsonPath = require.resolve("tailwindcss/package.json", {
+diff --git a/dist/esm/config.js b/dist/esm/config.js
+index 4fac08c138f101d6a6f4ad0a19d48511af2206ed..7289839c19adb8aa60225ca1e8e881eacb5c91b5 100644
+--- a/dist/esm/config.js
++++ b/dist/esm/config.js
+@@ -82,7 +82,9 @@ function _loadConfigFile() {
+ var getTailwindConfig = function(param) {
+   var tailwindVersion = param.tailwindVersion, appDirectory = param.appDirectory, userConfig = param.userConfig, extraConfig = param.extraConfig, designSystem = param.designSystem;
+   var content = getDefaultContent(appDirectory);
+-  var tailwindConfig = tailwindVersion === "3" ? {
++  var tailwindMajor = Number.parseInt(tailwindVersion, 10);
++  var useContentConfig = Number.isNaN(tailwindMajor) || tailwindMajor >= 3;
++  var tailwindConfig = useContentConfig ? {
+     content
+   } : {
+     purge: getV2PurgeConfig(content)
+diff --git a/dist/esm/utils.js b/dist/esm/utils.js
+index 1b92dfd85d15008b16cebbe98c999190e69807b3..6785a5721d269068e576ec64aee8397c68c603b9 100644
+--- a/dist/esm/utils.js
++++ b/dist/esm/utils.js
+@@ -1,15 +1,19 @@
+-function getTailwindPath(appDirectory) {
++function resolveFromPackage(packageName, appDirectory) {
+   try {
+-    return require.resolve("tailwindcss", {
++    return require.resolve(packageName, {
+       paths: [
+         appDirectory,
+         __dirname
+       ]
+     });
+   } catch (err) {
+-    return "tailwindcss";
++    return null;
+   }
+ }
++function getTailwindPath(appDirectory) {
++  var _a, _b;
++  return (_b = (_a = resolveFromPackage("@tailwindcss/postcss", appDirectory)) !== null && _a !== void 0 ? _a : resolveFromPackage("tailwindcss", appDirectory)) !== null && _b !== void 0 ? _b : "tailwindcss";
++}
+ function getTailwindVersion(appDirectory) {
+   try {
+     var packageJsonPath = require.resolve("tailwindcss/package.json", {
+diff --git a/dist/esm-node/config.js b/dist/esm-node/config.js
+index 78810749e5e7a4d05d5c235b3782994ff701b30a..20f7479071d0048e29762ba784a359b077a9cdbb 100644
+--- a/dist/esm-node/config.js
++++ b/dist/esm-node/config.js
+@@ -48,7 +48,9 @@ async function loadConfigFile(appDirectory) {
+ }
+ const getTailwindConfig = ({ tailwindVersion, appDirectory, userConfig, extraConfig, designSystem }) => {
+   const content = getDefaultContent(appDirectory);
+-  let tailwindConfig = tailwindVersion === "3" ? {
++  const tailwindMajor = Number.parseInt(tailwindVersion, 10);
++  const useContentConfig = Number.isNaN(tailwindMajor) || tailwindMajor >= 3;
++  let tailwindConfig = useContentConfig ? {
+     content
+   } : {
+     purge: getV2PurgeConfig(content)
+diff --git a/dist/esm-node/utils.js b/dist/esm-node/utils.js
+index f50b6c3369b064532753ab8e50f29414a3f35dfb..7fc3b9a571a8c315d58c7d20c317343930dc8b75 100644
+--- a/dist/esm-node/utils.js
++++ b/dist/esm-node/utils.js
+@@ -1,15 +1,19 @@
+-function getTailwindPath(appDirectory) {
++function resolveFromPackage(packageName, appDirectory) {
+   try {
+-    return require.resolve("tailwindcss", {
++    return require.resolve(packageName, {
+       paths: [
+         appDirectory,
+         __dirname
+       ]
+     });
+   } catch (err) {
+-    return "tailwindcss";
++    return null;
+   }
+ }
++function getTailwindPath(appDirectory) {
++  var _a, _b;
++  return (_b = (_a = resolveFromPackage("@tailwindcss/postcss", appDirectory)) !== null && _a !== void 0 ? _a : resolveFromPackage("tailwindcss", appDirectory)) !== null && _b !== void 0 ? _b : "tailwindcss";
++}
+ function getTailwindVersion(appDirectory) {
+   try {
+     const packageJsonPath = require.resolve("tailwindcss/package.json", {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@modern-js/plugin-tailwindcss':
+    hash: 80bfcffd3ad8b6dcdfa613d986c7b5002576a0f5b9786e81f2235a6265dba1ab
+    path: patches/@modern-js__plugin-tailwindcss.patch
+
 importers:
 
   .:
@@ -13,10 +18,10 @@ importers:
         version: 2.2.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@headlessui/tailwindcss':
         specifier: latest
-        version: 0.2.2(tailwindcss@4.1.13)
+        version: 0.2.2(tailwindcss@3.4.17)
       '@modern-js/plugin-tailwindcss':
         specifier: latest
-        version: 2.68.16(@modern-js/runtime@2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss@4.1.13)
+        version: 2.68.16(patch_hash=80bfcffd3ad8b6dcdfa613d986c7b5002576a0f5b9786e81f2235a6265dba1ab)(@modern-js/runtime@2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss@3.4.17)
       '@react-spring/web':
         specifier: latest
         version: 10.0.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -39,7 +44,7 @@ importers:
         specifier: latest
         version: 8.7.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-hook-form:
-        specifier: latest
+        specifier: ^7.0.0
         version: 7.63.0(react@19.1.1)
       storybook:
         specifier: latest
@@ -135,6 +140,9 @@ importers:
       storybook-addon-pseudo-states:
         specifier: latest
         version: 9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.17
       typescript:
         specifier: latest
         version: 5.9.2
@@ -143,6 +151,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -4445,6 +4457,9 @@ packages:
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
 
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -5526,6 +5541,9 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
 
@@ -5536,6 +5554,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -7259,6 +7280,10 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   line-diff@2.1.1:
     resolution: {integrity: sha512-vswdynAI5AMPJacOo2o+JJ4caDJbnY2NEqms4MhMW0NJbjh3skP/brpVTAgBxrg55NRZ2Vtw88ef18hnagIpYQ==}
 
@@ -7791,6 +7816,10 @@ packages:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -8206,8 +8235,32 @@ packages:
   postcss-functions@3.0.0:
     resolution: {integrity: sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==}
 
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
   postcss-js@2.0.3:
     resolution: {integrity: sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==}
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
 
   postcss-loader@4.3.0:
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
@@ -8305,6 +8358,12 @@ packages:
 
   postcss-nested@4.2.3:
     resolution: {integrity: sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==}
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
 
   postcss-normalize-charset@6.0.2:
     resolution: {integrity: sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==}
@@ -8769,6 +8828,9 @@ packages:
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
   read-pkg-up@1.0.1:
     resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
@@ -9518,6 +9580,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -9567,8 +9634,10 @@ packages:
     engines: {node: '>=8.9.0'}
     hasBin: true
 
-  tailwindcss@4.1.13:
-    resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
+  tailwindcss@3.4.17:
+    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -10348,6 +10417,8 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -11992,9 +12063,9 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       use-sync-external-store: 1.5.0(react@19.1.1)
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.1.13)':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17)':
     dependencies:
-      tailwindcss: 4.1.13
+      tailwindcss: 3.4.17
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -12653,14 +12724,14 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@modern-js/plugin-tailwindcss@2.68.16(@modern-js/runtime@2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss@4.1.13)':
+  '@modern-js/plugin-tailwindcss@2.68.16(patch_hash=80bfcffd3ad8b6dcdfa613d986c7b5002576a0f5b9786e81f2235a6265dba1ab)(@modern-js/runtime@2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(tailwindcss@3.4.17)':
     dependencies:
       '@modern-js/node-bundle-require': 2.68.16
       '@modern-js/runtime-utils': 2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@modern-js/utils': 2.68.16
       '@swc/helpers': 0.5.17
       babel-plugin-macros: 3.1.0
-      tailwindcss: 4.1.13
+      tailwindcss: 3.4.17
     optionalDependencies:
       '@modern-js/runtime': 2.68.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
@@ -15611,7 +15682,7 @@ snapshots:
 
   '@types/glob@9.0.0':
     dependencies:
-      glob: 7.2.3
+      glob: 11.0.3
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -16326,6 +16397,8 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
+
+  arg@5.0.2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -17369,6 +17442,10 @@ snapshots:
     dependencies:
       postcss: 8.4.31
 
+  css-declaration-sorter@7.3.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   css-loader@3.6.0(webpack@4.47.0):
     dependencies:
       camelcase: 5.3.1
@@ -17417,9 +17494,9 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.101.3(esbuild@0.25.10)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 6.0.1(postcss@8.4.31)
+      cssnano: 6.0.1(postcss@8.5.6)
       jest-worker: 29.7.0
-      postcss: 8.4.31
+      postcss: 8.5.6
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       webpack: 5.101.3(esbuild@0.25.10)
@@ -17500,15 +17577,59 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.4.31)
       postcss-unique-selectors: 6.0.4(postcss@8.4.31)
 
+  cssnano-preset-default@6.1.2(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      css-declaration-sorter: 7.3.0(postcss@8.5.6)
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-calc: 9.0.1(postcss@8.5.6)
+      postcss-colormin: 6.1.0(postcss@8.5.6)
+      postcss-convert-values: 6.1.0(postcss@8.5.6)
+      postcss-discard-comments: 6.0.2(postcss@8.5.6)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.6)
+      postcss-discard-empty: 6.0.3(postcss@8.5.6)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.6)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.6)
+      postcss-merge-rules: 6.1.1(postcss@8.5.6)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.6)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.6)
+      postcss-minify-params: 6.1.0(postcss@8.5.6)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.6)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.6)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.6)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.6)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.6)
+      postcss-normalize-string: 6.0.2(postcss@8.5.6)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.6)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.6)
+      postcss-normalize-url: 6.0.2(postcss@8.5.6)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.6)
+      postcss-ordered-values: 6.0.2(postcss@8.5.6)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.6)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.6)
+      postcss-svgo: 6.0.3(postcss@8.5.6)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.6)
+
   cssnano-utils@4.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+
+  cssnano-utils@4.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   cssnano@6.0.1(postcss@8.4.31):
     dependencies:
       cssnano-preset-default: 6.1.2(postcss@8.4.31)
       lilconfig: 2.1.0
       postcss: 8.4.31
+
+  cssnano@6.0.1(postcss@8.5.6):
+    dependencies:
+      cssnano-preset-default: 6.1.2(postcss@8.5.6)
+      lilconfig: 2.1.0
+      postcss: 8.5.6
 
   csso@5.0.5:
     dependencies:
@@ -17654,6 +17775,8 @@ snapshots:
       defined: 1.0.1
       minimist: 1.2.8
 
+  didyoumean@1.2.2: {}
+
   diffie-hellman@5.0.3:
     dependencies:
       bn.js: 4.12.2
@@ -17667,6 +17790,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dlv@1.1.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -19889,6 +20014,8 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lilconfig@3.1.3: {}
+
   line-diff@2.1.1:
     dependencies:
       levdist: 1.0.0
@@ -20463,6 +20590,8 @@ snapshots:
 
   object-hash@2.2.0: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -20780,8 +20909,7 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  pify@2.3.0:
-    optional: true
+  pify@2.3.0: {}
 
   pify@3.0.0: {}
 
@@ -20833,6 +20961,12 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
+  postcss-calc@9.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
   postcss-colormin@6.1.0(postcss@8.4.31):
     dependencies:
       browserslist: 4.26.2
@@ -20841,27 +20975,57 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-colormin@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-convert-values@6.1.0(postcss@8.4.31):
     dependencies:
       browserslist: 4.26.2
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-convert-values@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-discard-comments@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+
+  postcss-discard-comments@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   postcss-discard-duplicates@6.0.3(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
 
+  postcss-discard-duplicates@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-discard-empty@6.0.3(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
 
+  postcss-discard-empty@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-discard-overridden@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+
+  postcss-discard-overridden@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   postcss-flexbugs-fixes@4.2.1:
     dependencies:
@@ -20874,10 +21038,29 @@ snapshots:
       postcss: 6.0.23
       postcss-value-parser: 3.3.1
 
+  postcss-import@15.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.10
+
   postcss-js@2.0.3:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 7.0.39
+
+  postcss-js@4.1.0(postcss@8.5.6):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.6
+
+  postcss-load-config@4.0.2(postcss@8.5.6):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.8.1
+    optionalDependencies:
+      postcss: 8.5.6
 
   postcss-loader@4.3.0(postcss@7.0.39)(webpack@4.47.0):
     dependencies:
@@ -20905,6 +21088,12 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.4.31)
 
+  postcss-merge-longhand@6.0.5(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      stylehacks: 6.1.1(postcss@8.5.6)
+
   postcss-merge-rules@6.1.1(postcss@8.4.31):
     dependencies:
       browserslist: 4.26.2
@@ -20913,9 +21102,22 @@ snapshots:
       postcss: 8.4.31
       postcss-selector-parser: 6.1.2
 
+  postcss-merge-rules@6.1.1(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      caniuse-api: 3.0.0
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   postcss-minify-font-values@6.1.0(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-font-values@6.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.4.31):
@@ -20925,6 +21127,13 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-minify-gradients@6.0.3(postcss@8.5.6):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-minify-params@6.1.0(postcss@8.4.31):
     dependencies:
       browserslist: 4.26.2
@@ -20932,9 +21141,21 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-minify-params@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-minify-selectors@6.0.4(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-selector-parser: 6.1.2
+
+  postcss-minify-selectors@6.0.4(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-modules-extract-imports@2.0.0:
@@ -20996,13 +21217,27 @@ snapshots:
       postcss: 7.0.39
       postcss-selector-parser: 6.1.2
 
+  postcss-nested@6.2.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   postcss-normalize-charset@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
 
+  postcss-normalize-charset@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-normalize-display-values@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-display-values@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.4.31):
@@ -21010,9 +21245,19 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-positions@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-repeat-style@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.4.31):
@@ -21020,9 +21265,19 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-string@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-timing-functions@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.4.31):
@@ -21031,14 +21286,30 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-unicode@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-url@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-url@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-whitespace@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.2(postcss@8.4.31):
@@ -21047,15 +21318,32 @@ snapshots:
       postcss: 8.4.31
       postcss-value-parser: 4.2.0
 
+  postcss-ordered-values@6.0.2(postcss@8.5.6):
+    dependencies:
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-reduce-initial@6.1.0(postcss@8.4.31):
     dependencies:
       browserslist: 4.26.2
       caniuse-api: 3.0.0
       postcss: 8.4.31
 
+  postcss-reduce-initial@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      caniuse-api: 3.0.0
+      postcss: 8.5.6
+
   postcss-reduce-transforms@6.0.2(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-transforms@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@6.1.2:
@@ -21074,9 +21362,20 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
+  postcss-svgo@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      svgo: 3.3.2
+
   postcss-unique-selectors@6.0.4(postcss@8.4.31):
     dependencies:
       postcss: 8.4.31
+      postcss-selector-parser: 6.1.2
+
+  postcss-unique-selectors@6.0.4(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-value-parser@3.3.1: {}
@@ -21514,6 +21813,10 @@ snapshots:
       refractor: 3.6.0
 
   react@19.1.1: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
 
   read-pkg-up@1.0.1:
     dependencies:
@@ -22447,12 +22750,28 @@ snapshots:
       postcss: 8.4.31
       postcss-selector-parser: 6.1.2
 
+  stylehacks@6.1.1(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.2
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   stylis@4.3.2: {}
 
   sucrase@3.29.0:
     dependencies:
       commander: 4.1.1
       glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      ts-interface-checker: 0.1.13
+
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
@@ -22535,7 +22854,32 @@ snapshots:
       reduce-css-calc: 2.1.8
       resolve: 1.22.10
 
-  tailwindcss@4.1.13: {}
+  tailwindcss@3.4.17:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-import: 15.1.0(postcss@8.5.6)
+      postcss-js: 4.1.0(postcss@8.5.6)
+      postcss-load-config: 4.0.2(postcss@8.5.6)
+      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.10
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
 
   tapable@1.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  '@modern-js/plugin-tailwindcss': patches/@modern-js__plugin-tailwindcss.patch


### PR DESCRIPTION
## Summary
- pin Tailwind CSS back to v3, update peer dependency ranges, and add the compiler to devDependencies so installs no longer fail
- patch `@modern-js/plugin-tailwindcss` to prefer `@tailwindcss/postcss` when available and to treat Tailwind v3+ configs with the modern `content` field
- register the patched plugin through `pnpm-workspace.yaml` so the build picks it up

## Testing
- Not run (build currently fails upstream before our changes)

------
https://chatgpt.com/codex/tasks/task_e_68d6a304c81883318ffb8e71c8ad8600